### PR TITLE
Add `.note` and `.plan` to command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ stated provides a set of REPL commands to interact with the system:
 | `.in`    | Show the input template.                          | `None`                                                                                                | `.in`                                                          |
 | `.out`   | Show the current state of the template.           | `[<jsonPtr>]`                                                                                         | `.out` <br>`.out /data/accounts`                               |
 | `.state` | Show the current state of the template metadata.  | `None`                                                                                                | `.state`                                                       |
+| `.plan`  | Show the execution plan for rendering the template.  | `None`                                                                                             | `.plan`                                                        |
+| `.note`  | Show a separator line with a comment in the REPL output. | `<comment>`                                                                                    | `.note "Example 8"`                                            |
 
 
 The stated repl lets you experiment with templates. The simplest thing to do in the REPL is load a json file. The REPL

--- a/README.test.js
+++ b/README.test.js
@@ -17,7 +17,7 @@ const fs = require('fs');
 const {stringify} = require("./stated");
 /**
  * Regular expression for command extraction from README.md file. This program finds all the markup code blocks
- * that begin and and with ``` (markdown syntax for code block) and it extracts the cli command and the
+ * that begin and end with ``` (markdown syntax for code block) and it extracts the cli command and the
  * response. It then runs the cli command and compares the response to what is in the README.md. This ensures
  * that the README is always accurate.
  *


### PR DESCRIPTION
## Description

* README: Added the `.note` and `.plan` commands to the reference table
* Fixed typo in README.test.js comment

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [X] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
