### PR TITLE
+functions defined in jsonata behave normall in js

### DIFF
--- a/src/MetaInfoProducer.ts
+++ b/src/MetaInfoProducer.ts
@@ -15,8 +15,9 @@ export interface MetaInfo{
     expr__?: string;
     compiledExpr__?: jsonata.Expression;
     temp__?:boolean; //temp field indicates this field is !${...} and will be removed after template is processed
-    exprTargetJsonPointer__?:JsonPointerStructureArray|JsonPointerString
+    exprTargetJsonPointer__?:JsonPointerStructureArray|JsonPointerString //the pointer to the object that this expression executes on
     data__?:any
+    isFunction__?:boolean
 }
 
 export type JsonPointerStructureArray = (string|number)[];

--- a/src/StatedREPL.ts
+++ b/src/StatedREPL.ts
@@ -130,7 +130,7 @@ export default class StatedREPL {
         if(value === undefined){
             return null;
         }
-        if (value?._jsonata_lambda) {
+        if (value?._jsonata_lambda || value?._stated_function__) {
             return "{function:}";
         }
         if (key === 'compiledExpr__') {


### PR DESCRIPTION
## Description

hopefully this is not a breaking change and just makes functiond defined in jsonata expression callable like normal functions outside of stated. 

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
