### PR TITLE
Reuse template proessor

### DIFF
--- a/src/CliCore.ts
+++ b/src/CliCore.ts
@@ -120,7 +120,9 @@ export default class CliCore {
         const input = await this.readFileAndParse(filepath, importPath);
         const contextData = contextFilePath ? await this.readFileAndParse(contextFilePath, importPath) : {};
         options.importPath = importPath; //path is where local imports will be sourced from. We sneak path in with the options
-        this.templateProcessor = new TemplateProcessor(input, contextData, options);
+        if (!this.templateProcessor) {
+            this.templateProcessor = new TemplateProcessor(input, contextData, options);
+        }
         if(this.replServer){
             //make variable called 'template' accessible in REPL
             this.replServer.context.template = this.templateProcessor;
@@ -131,7 +133,7 @@ export default class CliCore {
         this.templateProcessor.logger.debug(`arguments: ${JSON.stringify(parsed)}`);
 
         try {
-            await this.templateProcessor.initialize();
+            await this.templateProcessor.initialize(input);
             if (oneshot === true) {
                 return this.templateProcessor.output;
             }

--- a/src/CliCore.ts
+++ b/src/CliCore.ts
@@ -122,6 +122,12 @@ export default class CliCore {
         options.importPath = importPath; //path is where local imports will be sourced from. We sneak path in with the options
         if (!this.templateProcessor) {
             this.templateProcessor = new TemplateProcessor(input, contextData, options);
+        } else {
+            this.templateProcessor.tagSet = new Set();
+            this.templateProcessor.options = options;
+            if (contextData) {
+                this.templateProcessor.setupContext(contextData);
+            }
         }
         if(this.replServer){
             //make variable called 'template' accessible in REPL
@@ -129,6 +135,7 @@ export default class CliCore {
         }
         this.templateProcessor.onInitialize = this.onInit;
         tags.forEach(a => this.templateProcessor.tagSet.add(a));
+        // set options
         this.templateProcessor.logger.level = this.logLevel;
         this.templateProcessor.logger.debug(`arguments: ${JSON.stringify(parsed)}`);
 
@@ -194,7 +201,7 @@ export default class CliCore {
         if (!this.templateProcessor) {
             throw new Error('Initialize the template first.');
         }
-        const parsed = CliCore.minimistArgs(replCmdInputStr)
+        const parsed = CliCore.minimistArgs(replCmdInputStr === undefined ? "" : replCmdInputStr)
         let {_:jsonPointer=""} = parsed;
         if(Array.isArray(jsonPointer)){
             jsonPointer = jsonPointer[0];
@@ -202,7 +209,7 @@ export default class CliCore {
                 jsonPointer = "";
             }
         }
-        return this.templateProcessor.out(jsonPointer);
+         return this.templateProcessor.out(jsonPointer);
     }
 
     state() {

--- a/src/CliCore.ts
+++ b/src/CliCore.ts
@@ -120,9 +120,10 @@ export default class CliCore {
         const input = await this.readFileAndParse(filepath, importPath);
         const contextData = contextFilePath ? await this.readFileAndParse(contextFilePath, importPath) : {};
         options.importPath = importPath; //path is where local imports will be sourced from. We sneak path in with the options
+        // if we initialize for the first time, we need to create a new instance of TemplateProcessor
         if (!this.templateProcessor) {
             this.templateProcessor = new TemplateProcessor(input, contextData, options);
-        } else {
+        } else { // if we are re-initializing, we need to reset the tagSet and options, if provided
             this.templateProcessor.tagSet = new Set();
             this.templateProcessor.options = options;
             if (contextData) {

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -254,7 +254,7 @@ export default class TemplateProcessor {
             this.executionPlans = {}; //clear execution plans
             let parsedJsonPtr = jp.parse(jsonPtr);
             parsedJsonPtr = isEqual(parsedJsonPtr, [""]) ? [] : parsedJsonPtr; //correct [""] to []
-            const metaInfos = await this.createMetaInfos(template, parsedJsonPtr);
+            const metaInfos = await this.createMetaInfos(template ? template : this.output, parsedJsonPtr);
             this.metaInfoByJsonPointer[jsonPtr] = metaInfos; //dictionary for template meta info, by import path (jsonPtr)
             this.sortMetaInfos(metaInfos);
             this.populateTemplateMeta(metaInfos);

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -219,14 +219,15 @@ export default class TemplateProcessor {
         }
     }
 
-    // initialize can be called in a few cases
-    // 1. From CLI when init command is called
-    // 2. from code, which creates a template processor and initialize the template passed in constructor
-    // 3. when template processor is created earlier and we want to re-initialize it with new template
-    // 4. during import, when we
+    // Template processor initialize can be called from 2 major use cases
+    // 1. initialize a new template processor template
+    // 2. initialize a new template for an existing template processor
+    // in the second case we need to reset the template processor data holders
     public async initialize(template: {} = undefined, jsonPtr = "/") {
         this.timerManager.clearAll();
-        // we need to reset template only if the template is passed with non-root json pointer
+
+        // if initialize is called with a template and root json pointer (which is "/" b default)
+        // we need to reset the template. Otherwise, we rely on the one provided in the constructor
         if (template !== undefined && jsonPtr === "/") {
             this.resetTemplate(template)
         }

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -185,6 +185,7 @@ export default class TemplateProcessor {
         this.isInitializing = false;
         this.changeCallbacks = new Map();
         this.functionGenerators = new Map();
+        this.tagSet = new Set();
     }
 
     // resetting template means that we are resetting all data holders and set up new template
@@ -194,12 +195,11 @@ export default class TemplateProcessor {
         this.templateMeta = JSON.parse(JSON.stringify(template));// Copy the given template to `initialize the templateMeta
         this.warnings = [];
         this.metaInfoByJsonPointer = {}; //there will be one key "/" for the root and one additional key for each import statement in the template
-        this.tagSet = new Set();
         this.errorReport = {}
         this.tempVars = [];
     }
 
-    private setupContext(context: {}) {
+    setupContext(context: {}) {
         this.context = merge(
             {},
             TemplateProcessor.DEFAULT_FUNCTIONS,
@@ -254,7 +254,7 @@ export default class TemplateProcessor {
             this.executionPlans = {}; //clear execution plans
             let parsedJsonPtr = jp.parse(jsonPtr);
             parsedJsonPtr = isEqual(parsedJsonPtr, [""]) ? [] : parsedJsonPtr; //correct [""] to []
-            const metaInfos = await this.createMetaInfos(template ? template : this.output, parsedJsonPtr);
+            const metaInfos = await this.createMetaInfos(template === undefined ? this.output : template , parsedJsonPtr);
             this.metaInfoByJsonPointer[jsonPtr] = metaInfos; //dictionary for template meta info, by import path (jsonPtr)
             this.sortMetaInfos(metaInfos);
             this.populateTemplateMeta(metaInfos);

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -218,9 +218,11 @@ export default class TemplateProcessor {
         }
     }
 
-    public async initialize(template = this.input, jsonPtr = "/") {
+    public async initialize(template: {} = undefined, jsonPtr = "/") {
         this.timerManager.clearAll();
-        this.resetTemplate(template)
+        if (template !== undefined) {
+            this.resetTemplate(template)
+        }
         this.onInitialize && await this.onInitialize();
         if (jsonPtr === "/" && this.isInitializing) {
             console.error("-----Initialization '/' is already in progress. Ignoring concurrent call to initialize!!!! Strongly consider checking your JS code for errors.-----");
@@ -245,7 +247,7 @@ export default class TemplateProcessor {
             this.executionPlans = {}; //clear execution plans
             let parsedJsonPtr = jp.parse(jsonPtr);
             parsedJsonPtr = isEqual(parsedJsonPtr, [""]) ? [] : parsedJsonPtr; //correct [""] to []
-            const metaInfos = await this.createMetaInfos(template, parsedJsonPtr);
+            const metaInfos = await this.createMetaInfos(this.input, parsedJsonPtr);
             this.metaInfoByJsonPointer[jsonPtr] = metaInfos; //dictionary for template meta info, by import path (jsonPtr)
             this.sortMetaInfos(metaInfos);
             this.populateTemplateMeta(metaInfos);

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -179,19 +179,23 @@ export default class TemplateProcessor {
         this.import = this.import.bind(this); // allows clients to directly call import on this TemplateProcessor
         this.logger = new ConsoleLogger("info");
         this.setupContext(context);
+        this.resetTemplate(template);
+        this.options = options;
+        this.debugger = new Debugger(this.templateMeta, this.logger);
+        this.isInitializing = false;
+        this.changeCallbacks = new Map();
+        this.functionGenerators = new Map();
+    }
+
+    private resetTemplate(template) {
         this.input = JSON.parse(JSON.stringify(template));
         this.output = template; //initial output is input template
-        this.templateMeta = JSON.parse(JSON.stringify(this.output));// Copy the given template to `initialize the templateMeta
+        this.templateMeta = JSON.parse(JSON.stringify(template));// Copy the given template to `initialize the templateMeta
         this.warnings = [];
         this.metaInfoByJsonPointer = {}; //there will be one key "/" for the root and one additional key for each import statement in the template
         this.tagSet = new Set();
-        this.options = options;
-        this.debugger = new Debugger(this.templateMeta, this.logger);
         this.errorReport = {}
-        this.isInitializing = false;
         this.tempVars = [];
-        this.changeCallbacks = new Map();
-        this.functionGenerators = new Map();
     }
 
     private setupContext(context: {}) {
@@ -216,6 +220,7 @@ export default class TemplateProcessor {
 
     public async initialize(template = this.input, jsonPtr = "/") {
         this.timerManager.clearAll();
+        this.resetTemplate(template)
         this.onInitialize && await this.onInitialize();
         if (jsonPtr === "/" && this.isInitializing) {
             console.error("-----Initialization '/' is already in progress. Ignoring concurrent call to initialize!!!! Strongly consider checking your JS code for errors.-----");

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -187,6 +187,7 @@ export default class TemplateProcessor {
         this.functionGenerators = new Map();
     }
 
+    // resetting template means that we are resetting all data holders and set up new template
     private resetTemplate(template) {
         this.input = JSON.parse(JSON.stringify(template));
         this.output = template; //initial output is input template
@@ -218,9 +219,15 @@ export default class TemplateProcessor {
         }
     }
 
+    // initialize can be called in a few cases
+    // 1. From CLI when init command is called
+    // 2. from code, which creates a template processor and initialize the template passed in constructor
+    // 3. when template processor is created earlier and we want to re-initialize it with new template
+    // 4. during import, when we
     public async initialize(template: {} = undefined, jsonPtr = "/") {
         this.timerManager.clearAll();
-        if (template !== undefined) {
+        // we need to reset template only if the template is passed with non-root json pointer
+        if (template !== undefined && jsonPtr === "/") {
             this.resetTemplate(template)
         }
         this.onInitialize && await this.onInitialize();
@@ -247,7 +254,7 @@ export default class TemplateProcessor {
             this.executionPlans = {}; //clear execution plans
             let parsedJsonPtr = jp.parse(jsonPtr);
             parsedJsonPtr = isEqual(parsedJsonPtr, [""]) ? [] : parsedJsonPtr; //correct [""] to []
-            const metaInfos = await this.createMetaInfos(this.input, parsedJsonPtr);
+            const metaInfos = await this.createMetaInfos(template, parsedJsonPtr);
             this.metaInfoByJsonPointer[jsonPtr] = metaInfos; //dictionary for template meta info, by import path (jsonPtr)
             this.sortMetaInfos(metaInfos);
             this.populateTemplateMeta(metaInfos);


### PR DESCRIPTION
## Description

This change ensures that we can reuse an instance of customized template processor. 

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
