### PR TITLE
catch errors on open

### DIFF
--- a/src/CliCore.ts
+++ b/src/CliCore.ts
@@ -329,10 +329,19 @@ public async open(directory: string = this.currentDirectory) {
     if(directory === ""){
         directory = this.currentDirectory;
     }
-    // Read all files from the directory
-    const files = await fs.promises.readdir(directory);
+
+    let files: string[] = undefined;
+    try {
+        // Read all files from the directory
+        files = await fs.promises.readdir(directory);
+    } catch (error) {
+        console.log(`Error reading directory ${directory}: ${error}`);
+        console.log('Changed directory with .cd or .open an/existing/directory');
+        this.replServer.displayPrompt();
+        return {error: `Error reading directory ${directory}: ${error}`};
+    }
     // Filter out only .json and .yaml files
-    const templateFiles = files.filter(file => file.endsWith('.json') || file.endsWith('.yaml'));
+    const templateFiles: string[] = files.filter(file => file.endsWith('.json') || file.endsWith('.yaml'));
 
     // Display the list of files to the user
     templateFiles.forEach((file, index) => {


### PR DESCRIPTION
## Description

```
> .open
Error reading directory /Users/sesergee/projects/sandbox/stated-js/example: Error: ENOENT: no such file or directory, scandir '/Users/sesergee/projects/sandbox/stated-js/example'
Changed directory with .cd or .open an/existing/directory
> .open blah
Error reading directory blah: Error: ENOENT: no such file or directory, scandir 'blah'
Changed directory with .cd or .open an/existing/directory
```

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
