### PR TITLE
Intervals

### DIFF
--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -1241,11 +1241,22 @@ export default class TemplateProcessor {
 
         //----------------- utility functions ----------------//
 
+        const isInterval = (metaInf:MetaInfo): boolean =>{
+            const {data__} = metaInf;
+            return data__ && this.timerManager.isInterval(data__);
+        }
+
         const isFunction = (jsonPointer)=>{
+
             if(!jp.has(this.templateMeta, jsonPointer)){
                 return false;
             }
             const metaInf = jp.get(this.templateMeta, jsonPointer);
+            //treat intervals same as immutable functions. Changes should not propagate through an interval causing
+            //interval re-evaluation
+            if(isInterval(metaInf)){
+                return true;
+            }
             return !!metaInf.isFunction__;
         }
 

--- a/src/TimerManager.ts
+++ b/src/TimerManager.ts
@@ -60,6 +60,10 @@ class TimerManager {
         this.clearAllTimeouts();
         this.clearAllIntervals();
     }
+
+    isInterval(interval: any){
+        return this.intervals.has(interval);
+    }
 }
 
 export { TimerManager };


### PR DESCRIPTION
## Description

make intervals immutable. Once an interval id has been returned to a template field, it cannot be altered. This blocks
'.from' plans from causing an interval to be re-evaluated, which is almost never what is actually desired.

## Type of Change

- [ ] Bug Fix
- [x ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
