### PR TITLE
Delete untracked pointer

### DIFF
--- a/example/restoreSnapshot.json
+++ b/example/restoreSnapshot.json
@@ -7,12 +7,12 @@
   "output": {
     "count": 3,
     "counter": "--interval/timeout--",
-    "stop": "not done"
+    "stop": "not done",
+    "onlyInSnapshot": "dataFromSnapshot"
   },
   "options": {
     "snapshot": {
       "seconds": 1
-    },
-    "importPath": "/Users/sesergee/projects/sandbox/workflows/stated-workflow"
+    }
   }
 }

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -1017,7 +1017,23 @@ export default class TemplateProcessor {
             jp.get(this.templateMeta, entryPoint).didUpdate__ = didUpdate;
         } else {
             // Check if the node contains an expression. If so, print a warning and return.
-            const firstMeta = jp.get(this.templateMeta, entryPoint);
+            let firstMeta;
+            try {
+                firstMeta = jp.get(this.templateMeta, entryPoint);
+            } catch (error) {
+                if (op != 'delete') {
+                    throw error;
+                }
+
+                this.logger.log('warn', `The reference with json pointer ${entryPoint} does not exist in the templateMeta, attempting to delete it from the output`);
+                try {
+                    jp.remove(this.output, entryPoint);
+                } catch (error) {
+                    this.logger.log('warn', `The reference with json pointer ${entryPoint} does not exist in the output. The operation is ignored`);
+                }
+                return;
+            }
+
             if (firstMeta.expr__ !== undefined && op !== "setDeferred") { //setDeferred allows $defer('/foo') to 'self replace' with a value
                 this.logger.log('warn', `Attempted to replace expressions with data under ${entryPoint}. This operation is ignored.`);
             } else {

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -1021,17 +1021,20 @@ export default class TemplateProcessor {
             try {
                 firstMeta = jp.get(this.templateMeta, entryPoint);
             } catch (error) {
-                if (op != 'delete') {
-                    throw error;
-                }
-
-                this.logger.log('warn', `The reference with json pointer ${entryPoint} does not exist in the templateMeta, attempting to delete it from the output`);
-                try {
-                    jp.remove(this.output, entryPoint);
-                } catch (error) {
-                    this.logger.log('warn', `The reference with json pointer ${entryPoint} does not exist in the output. The operation is ignored`);
-                }
-                return;
+                this.logger.log('warn', `The reference with json pointer ${entryPoint} does not exist in the templateMeta, attempting to evaluateNode`);
+                await this.evaluateNode(entryPoint, data, op);
+                firstMeta = jp.get(this.templateMeta, entryPoint);
+                // if (op != 'delete') {
+                //     throw error;
+                // }
+                //
+                // this.logger.log('warn', `The reference with json pointer ${entryPoint} does not exist in the templateMeta, attempting to delete it from the output`);
+                // try {
+                //     jp.remove(this.output, entryPoint);
+                // } catch (error) {
+                //     this.logger.log('warn', `The reference with json pointer ${entryPoint} does not exist in the output. The operation is ignored`);
+                // }
+                // return;
             }
 
             if (firstMeta.expr__ !== undefined && op !== "setDeferred") { //setDeferred allows $defer('/foo') to 'self replace' with a value

--- a/src/test/TemplateProcessor.test.js
+++ b/src/test/TemplateProcessor.test.js
@@ -2119,3 +2119,77 @@ test("dataChangeCallback on delete op", async () => {
     expect(tp.output.foo).toBeUndefined();
 })
 
+test("dataChangeCallback on delete op from Snapshot", async () => {
+    const snapshot = {
+        "template": {
+            "step": {
+                "name": "step0"
+            }
+        },
+        "output": {
+            "some": "thing",
+            "step": {
+                "name": "step0",
+                "log": {
+                    "han": {
+                        "start": {
+                            "timestamp": 1709228824377,
+                            "args": "han"
+                        },
+                        "end": {
+                            "timestamp": 1709228825880,
+                            "out": {
+                                "name": "Han Solo",
+                                "height": "180",
+                                "mass": "80",
+                                "hair_color": "brown",
+                                "skin_color": "fair",
+                                "eye_color": "brown",
+                                "birth_year": "29BBY",
+                                "gender": "male",
+                                "homeworld": "https://swapi.dev/api/planets/22/",
+                                "films": [
+                                    "https://swapi.dev/api/films/1/",
+                                    "https://swapi.dev/api/films/2/",
+                                    "https://swapi.dev/api/films/3/"
+                                ],
+                                "species": [],
+                                "vehicles": [],
+                                "starships": [
+                                    "https://swapi.dev/api/starships/10/",
+                                    "https://swapi.dev/api/starships/22/"
+                                ],
+                                "created": "2014-12-10T16:49:14.582000Z",
+                                "edited": "2014-12-20T21:17:50.334000Z",
+                                "url": "https://swapi.dev/api/people/14/"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "options": {
+        }
+    }
+    const tp = TemplateProcessor.constructFromSnapshotObject(snapshot);
+    let done;
+    let latch = new Promise(resolve => done = resolve);
+    tp.setDataChangeCallback('/step/log/han', (data, jsonPtr, removed)=>{
+        // jp.get(tp.metaInfo, jsonPtr);
+        done();
+    });
+    try {
+        tp.initialize();
+        tp.setData("/step/log/han", undefined, "delete");
+        await latch;
+        console.log(tp.output);
+        while (tp.output.step.log.han !== undefined) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+        }
+    } catch (error) {
+        console.log(error);
+        jest.fail(error);
+    }
+    expect(tp.output.step.log.han).toBeNull();
+})
+

--- a/src/test/TemplateProcessor.test.js
+++ b/src/test/TemplateProcessor.test.js
@@ -2175,11 +2175,12 @@ test("dataChangeCallback on delete op from Snapshot", async () => {
     let done;
     let latch = new Promise(resolve => done = resolve);
     tp.setDataChangeCallback('/step/log/han', (data, jsonPtr, removed)=>{
-        // jp.get(tp.metaInfo, jsonPtr);
-        done();
-    });
+        if (removed){
+            done();
+        }
+     });
     try {
-        tp.initialize();
+        await tp.initializeFromSnapshotObject(snapshot);
         tp.setData("/step/log/han", undefined, "delete");
         await latch;
         console.log(tp.output);
@@ -2190,6 +2191,6 @@ test("dataChangeCallback on delete op from Snapshot", async () => {
         console.log(error);
         jest.fail(error);
     }
-    expect(tp.output.step.log.han).toBeNull();
+    expect(tp.output.step.log.han).toBeUndefined();
 })
 


### PR DESCRIPTION
## Description
This code ensures that a jsonPointer in template output restored from a snapshot can be deleted, even if it misses the metadata. 

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
