### PR TITLE
add prepareSnapshot

### DIFF
--- a/src/CliCore.ts
+++ b/src/CliCore.ts
@@ -159,7 +159,8 @@ export default class CliCore {
         if (!this.templateProcessor && !fromSnapshot) {
             this.templateProcessor = new TemplateProcessor(input, contextData, options);
         } else if (!this.templateProcessor && fromSnapshot) {
-            this.templateProcessor = new TemplateProcessor(input.template, contextData, input.options);
+            await TemplateProcessor.prepareSnapshotInPlace(input); // input is a snapshot
+            this.templateProcessor = TemplateProcessor.constructFromSnapshotObject(input, contextData);
         } else { // if we are re-initializing, we need to reset the tagSet and options, if provided
             this.templateProcessor.tagSet = new Set();
             this.templateProcessor.options = options;
@@ -182,7 +183,8 @@ export default class CliCore {
             if(tail !== undefined){
                 tailPromise = this.tail(tail);
             }
-            if (fromSnapshot) {
+            if (fromSnapshot) { // restore from a snapshot
+                if (!input.prepared) await TemplateProcessor.prepareSnapshotInPlace(input); // check if already prepared
                 await this.templateProcessor.initialize(input.template,"/", input.output);
             } else {
                 await this.templateProcessor.initialize(input);

--- a/src/JsonPointer.ts
+++ b/src/JsonPointer.ts
@@ -1,3 +1,32 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016 Manuel Stofer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+ */
+/*
+    This class is mostly a cut-n-paste of the MIT licensed source code noted above
+ */
+import {JsonPointerString} from "./MetaInfoProducer.js";
+
 export default class JsonPointer {
     /**
      * Convenience wrapper around jp.
@@ -144,10 +173,10 @@ export default class JsonPointer {
      * @param {function} iterator
      * @param {function} descend
      */
-    static walk(obj, iterator, descend) {
+    static walk(obj, iterator, descend?) {
         const refTokens = [];
 
-        descend = descend || function (value) {
+        descend = descend || function (value, ptrString:JsonPointerString) {
             const type = Object.prototype.toString.call(value);
             return type === '[object Object]' || type === '[object Array]';
         };
@@ -155,10 +184,11 @@ export default class JsonPointer {
         (function next(cur) {
             for (const [key, value] of Object.entries(cur)) {
                 refTokens.push(String(key));
-                if (descend(value)) {
+                const ptrString = JsonPointer.compile(refTokens);
+                if (descend(value, ptrString)) {
                     next(value);
                 } else {
-                    iterator(value, JsonPointer.compile(refTokens));
+                    iterator(value, ptrString);
                 }
                 refTokens.pop();
             }

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -411,12 +411,6 @@ export default class TemplateProcessor {
         }
     }
 
-    public async initializeFromSnapshot(snapshot:Snapshot){
-        //this = {...this, ...snapshot};
-        this.timerManager.clearAll();
-        this.output
-    }
-
     close():void{
         this.timerManager.clearAll();
         this.changeCallbacks.clear();

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -931,7 +931,15 @@ export default class TemplateProcessor {
     }
 
 
-    async setData(jsonPtr, data=null, op="set") {
+    /**
+     * Sets or deletes data based on the specified operation.
+     * @async
+     * @param {string} jsonPtr - The JSON pointer indicating where to apply the operation.
+     * @param {*} [data=null] - The data to be used with the set or setDeferred operation.
+     * @param {"set"|"delete"|"setDeferred"} [op="set"] - The operation to perform - setDeferred is for internal use
+     * @returns {Promise<void>} A promise that resolves when the operation is complete.
+     */
+    async setData(jsonPtr, data=null, op:"set"|"delete"|"setDeferred"="set") {
         this.isEnabled("debug") && this.logger.debug(`setData on ${jsonPtr} for TemplateProcessor uid=${this.uniqueId}`)
         //get all the jsonPtrs we need to update, including this one, to percolate the change
         const sortedJsonPtrs = [...this.from(jsonPtr)]; //defensive copy

--- a/src/test/TemplateProcessor.test.js
+++ b/src/test/TemplateProcessor.test.js
@@ -2137,3 +2137,78 @@ test("snapshot contains injected fields", async () => {
     expect(tpRestored.output.b.c.g).toBe('YYY');
 })
 
+test("dataChangeCallback on delete op from Snapshot", async () => {
+    const snapshot = {
+        "template": {
+            "step": {
+                "name": "step0"
+            }
+        },
+        "output": {
+            "some": "thing",
+            "step": {
+                "name": "step0",
+                "log": {
+                    "han": {
+                        "start": {
+                            "timestamp": 1709228824377,
+                            "args": "han"
+                        },
+                        "end": {
+                            "timestamp": 1709228825880,
+                            "out": {
+                                "name": "Han Solo",
+                                "height": "180",
+                                "mass": "80",
+                                "hair_color": "brown",
+                                "skin_color": "fair",
+                                "eye_color": "brown",
+                                "birth_year": "29BBY",
+                                "gender": "male",
+                                "homeworld": "https://swapi.dev/api/planets/22/",
+                                "films": [
+                                    "https://swapi.dev/api/films/1/",
+                                    "https://swapi.dev/api/films/2/",
+                                    "https://swapi.dev/api/films/3/"
+                                ],
+                                "species": [],
+                                "vehicles": [],
+                                "starships": [
+                                    "https://swapi.dev/api/starships/10/",
+                                    "https://swapi.dev/api/starships/22/"
+                                ],
+                                "created": "2014-12-10T16:49:14.582000Z",
+                                "edited": "2014-12-20T21:17:50.334000Z",
+                                "url": "https://swapi.dev/api/people/14/"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "options": {
+        }
+    }
+    await TemplateProcessor.prepareSnapshotInPlace(snapshot);
+    const tp = TemplateProcessor.constructFromSnapshotObject(snapshot);
+    let done;
+    let latch = new Promise(resolve => done = resolve);
+    tp.setDataChangeCallback('/step/log/han', (data, jsonPtr, removed)=>{
+        if (removed){
+            done();
+        }
+    });
+    try {
+        await tp.initializeFromSnapshotObject(snapshot);
+        await tp.setData("/step/log/han", undefined, "delete");
+        await latch;
+    } catch (error) {
+        console.log(error);
+        jest.fail(error);
+    }
+    expect(tp.output).toStrictEqual({ some: 'thing', step: { name: 'step0', log: {} } });
+    //try to delete the log a second time, just to make sure no double-delete problems
+    await tp.setData("/step/log/han", undefined, "delete");
+
+})
+


### PR DESCRIPTION
add prepareSnapshot method, and basic test. Verifies that data set into template output, and emitted in snapshot output is merged back into template when the snapshot is prepared.

## Type of Change

- [ x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
