### PR TITLE
Forked

### DIFF
--- a/example/homeworlds-forked.yaml
+++ b/example/homeworlds-forked.yaml
@@ -1,0 +1,7 @@
+data: ${['luke', 'han', 'leia', 'chewbacca', 'darth', 'ben', 'c-3po', 'yoda'].($forked('/name',$))}
+name: null
+personDetails: ${ (name!=null?$fetch('https://swapi.tech/api/people/?name='&name).json().result[0]:null)}
+homeworldURL: ${ personDetails!=null?personDetails.properties.homeworld:null ~> $save}
+homeworldDetails: ${ homeworldURL!=null?$fetch(homeworldURL).json().result:null }
+homeworldName: ${ homeworldDetails!=null?$joined('/homeworlds/-', homeworldDetails.properties.name):null }
+homeworlds: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stated-js",
-  "version": "0.0.109",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stated-js",
-      "version": "0.0.109",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -89,5 +89,8 @@
   "jest": {
     "transform": {}
   },
-  "type": "module"
+  "type": "module",
+  "browser":{
+    "child_process": false
+  }
 }

--- a/src/ExecutionStatus.ts
+++ b/src/ExecutionStatus.ts
@@ -1,0 +1,77 @@
+import { JsonPointerString } from "./MetaInfoProducer.js";
+import TemplateProcessor, {MutationPlan, Op, PlanStep, Fork} from "./TemplateProcessor.js";
+import StatedREPL from "./StatedREPL.js";
+
+type StoredOp = {forkId:string, jsonPtr:JsonPointerString, data:any, op:string};
+export class ExecutionStatus {
+    private statuses: Set<MutationPlan>;
+    constructor() {
+        this.statuses = new Set();
+    }
+    public begin(mutationPlan:MutationPlan) {
+        this.statuses.add(mutationPlan)
+    }
+
+    public end(mutationPlan: MutationPlan) {
+        this.statuses.delete(mutationPlan);
+    }
+
+    public clear() {
+        this.statuses.clear();
+    }
+
+    public toJsonString():string{
+        return StatedREPL.stringify(this.toJsonObject());
+    }
+
+    public toJsonObject():object{
+        const outputsByForkId =new  Map<string, Fork>();
+        Array.from(this.statuses).forEach((mutationPlan:MutationPlan)=>{
+            const {forkId, output, forkStack}= mutationPlan;
+            outputsByForkId.set(forkId, {forkId, output} as Fork);
+            forkStack.forEach((fork:Fork)=>{
+                outputsByForkId.set(fork.forkId, fork);
+            });
+
+        });
+        const snapshot = {
+            mvcc:Array.from(outputsByForkId.values()),
+            plans: Array.from(this.statuses).map(this.mutationPlanToJSON)
+        };
+        return JSON.parse(StatedREPL.stringify(snapshot));
+    }
+
+    private planStepToJSON = (planStep:PlanStep):object => {
+        const {forkId,forkStack,jsonPtr, op, data, output} = planStep;
+        return {
+            forkId,
+            forkStack: forkStack.map(fork=>forkId),
+            jsonPtr,
+            data,
+            op
+        };
+    }
+
+    private mutationPlanToJSON = (mutationPlan:MutationPlan):object => {
+        const {forkId,forkStack,sortedJsonPtrs, lastCompletedStep, op, data, output} = mutationPlan;
+        const json = {
+            forkId,
+            forkStack: forkStack.map(fork=>fork.forkId),
+            sortedJsonPtrs,
+            op,
+            data
+
+        };
+        if(lastCompletedStep){
+            json['lastCompletedStep'] = lastCompletedStep.jsonPtr; //all we need to record is jsonpointer of last completed step
+        }
+        return json;
+    }
+
+
+    public restore(tp:TemplateProcessor){
+        this.statuses.forEach(mutationPlan=>{
+           // (tp as InternalMethods).executePlan(mutationPlan);
+        });
+    }
+}

--- a/src/test/DependencyFinder.test.js
+++ b/src/test/DependencyFinder.test.js
@@ -778,6 +778,24 @@ test("empty string", () => {
     expect(deps).toEqual([]);
 });
 
+test("acc^($.val)", () => {
+    const program = "acc^($.val)";
+    const df = new DependencyFinder(program);
+    const deps = df.findDependencies();
+    expect(deps).toEqual([
+        [
+            "acc",
+            "",
+            "val"
+        ],
+        [
+            "acc"
+        ]
+    ]);
+});
+
+
+
 
 
 

--- a/src/utils/FetchWrapper.ts
+++ b/src/utils/FetchWrapper.ts
@@ -1,0 +1,21 @@
+/**
+ * Performs a fetch request and enhances error handling.
+ * If the response is not ok, it rejects with a custom error object that includes a `.json()` method.
+ * This `.json()` method, when called, returns the error object itself, facilitating error handling
+ * for scenarios where the caller expects to call `.json()` on the response.
+ *
+ * @param {string} url - The URL to fetch.
+ * @param {Object} [opts] - Optional fetch options.
+ * @returns {Promise<Response>} A promise that resolves to the fetch response. If the response is not ok,
+ * it rejects with a custom error object consistent with Stated template-level error handling e.g. {error:{message:"..."}}.
+ * @throws {Object} The custom error object with a `.json()` method if the response is not ok. The error
+ * object structure is: { error: { message: string } }.
+ *
+ */
+export const saferFetch = async (url, opts) => {
+    const response = await fetch(url, opts);
+    if (!response.ok) {
+        console.error(`HTTP response not OK for '${url}', status: ${response.status}, statusText: ${response.statusText}`);
+    }
+    return response;
+};

--- a/src/utils/Save.ts
+++ b/src/utils/Save.ts
@@ -1,0 +1,6 @@
+import {ExecutionStatus} from "../ExecutionStatus.js";
+
+export const save = (output:object, status:ExecutionStatus, filename:string="stated_snapshot.json")=>{
+    console.error(status.toJsonString());
+    return
+}

--- a/src/utils/Sleep.ts
+++ b/src/utils/Sleep.ts
@@ -1,0 +1,12 @@
+import {TimerManager} from "../TimerManager.js";
+
+export class Sleep{
+    private timerManager: TimerManager;
+    constructor(timerManager:TimerManager) {
+        this.timerManager = timerManager;
+    }
+
+    public sleep = async (delayMs)=>{
+        await new Promise(resolve => this.timerManager.setTimeout(resolve, delayMs))
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,6 +67,7 @@ export default {
             zlib: false,
             http: false,
             https:false,
+            child_process: false
         }
     },
     plugins: [


### PR DESCRIPTION
## Description

$forked and $joined introduce multiversion concurrency control (MVCC). See 'forked1' test. The $forked keyword branches the plan onto a copy of the output, and the $joined command merges the fork. This allows for plans with I/O heavy steps like $fetch to safely run in parallel, without blocking/serializing.

## Type of Change

- [ ] Bug Fix
- [x ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
