### PR TITLE
Fix missing types export

### DIFF
--- a/webpack.config.cjs.js
+++ b/webpack.config.cjs.js
@@ -72,7 +72,7 @@ export default {
         new CopyPlugin({
             patterns: [
                 {
-                    from: 'src',
+                    from: 'types/src',
                     to: 'src',
                     globOptions: {
                         ignore: ['**/test/**'], // Exclude the src/test directory

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,7 +78,7 @@ export default {
         new CopyPlugin({
             patterns: [
                 {
-                    from: 'src',
+                    from: 'types/src',
                     to: 'src',
                     globOptions: {
                         ignore: ['**/test/**'], // Exclude the src/test directory


### PR DESCRIPTION
## Description

Joshua and I came across type errors when trying to upgrade to stated@0.0.98+. I think there was a folder name typo in https://github.com/cisco-open/stated/commit/a86478a05e6c41d73e0c7ecf415764301d24e540 that caused the type exports to get dropped and the *.ts files to get exported instead.  
 
<img width="845" alt="Screenshot 2024-03-18 at 10 39 13 AM" src="https://github.com/cisco-open/stated/assets/437830/12c97a83-deeb-4cbd-bfc1-ea7879e3d682">

<img width="1227" alt="Screenshot 2024-03-18 at 10 44 20 AM" src="https://github.com/cisco-open/stated/assets/437830/b86a91c0-cbae-4173-a636-3b5d62bea9e5">


## Type of Change

- [ x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
