### PR TITLE
kill off didUpdate__

### DIFF
--- a/src/ExecutionStatus.ts
+++ b/src/ExecutionStatus.ts
@@ -1,18 +1,18 @@
 import { JsonPointerString } from "./MetaInfoProducer.js";
-import TemplateProcessor, {MutationPlan, Op, PlanStep, Fork} from "./TemplateProcessor.js";
+import TemplateProcessor, {Plan, Op, PlanStep, Fork} from "./TemplateProcessor.js";
 import { stringifyTemplateJSON } from './utils/stringify.js';
 
 type StoredOp = {forkId:string, jsonPtr:JsonPointerString, data:any, op:string};
 export class ExecutionStatus {
-    private statuses: Set<MutationPlan>;
+    private statuses: Set<Plan>;
     constructor() {
         this.statuses = new Set();
     }
-    public begin(mutationPlan:MutationPlan) {
+    public begin(mutationPlan:Plan) {
         this.statuses.add(mutationPlan)
     }
 
-    public end(mutationPlan: MutationPlan) {
+    public end(mutationPlan: Plan) {
         this.statuses.delete(mutationPlan);
     }
 
@@ -26,7 +26,7 @@ export class ExecutionStatus {
 
     public toJsonObject():object{
         const outputsByForkId =new  Map<string, Fork>();
-        Array.from(this.statuses).forEach((mutationPlan:MutationPlan)=>{
+        Array.from(this.statuses).forEach((mutationPlan:Plan)=>{
             const {forkId, output, forkStack}= mutationPlan;
             outputsByForkId.set(forkId, {forkId, output} as Fork);
             forkStack.forEach((fork:Fork)=>{
@@ -52,7 +52,7 @@ export class ExecutionStatus {
         };
     }
 
-    private mutationPlanToJSON = (mutationPlan:MutationPlan):object => {
+    private mutationPlanToJSON = (mutationPlan:Plan):object => {
         const {forkId,forkStack,sortedJsonPtrs, lastCompletedStep, op, data, output} = mutationPlan;
         const json = {
             forkId,


### PR DESCRIPTION
## Description

using MetaInfo.didUpdate__ was not fork sage. Killed it off and moved didUpdate into fork safe constructs.

## Type of Change

- [x ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
