### PR TITLE
fix web targets by making sure no references to node stuff creeps int…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Upload npm debug log on failure
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: npm-debug-log
           path: /home/runner/.npm/_logs/*-debug.log

--- a/README.md
+++ b/README.md
@@ -1726,7 +1726,7 @@ All JSONata functions are available in Stated.
 Stated provides many functions not provided out of the box by JSONata. 
 
 ### $env
-`$env` is a function used to read environment variables for Stated templates running in node.js. A default value can 
+`$env` is a function used to read environment variables for Stated templates running in Node.js environment. A default value can 
 be specified. If there is no default provided and no such variable exists in node `process.env` an error is returned.
 ```json
 > .init -f example/ex24.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stated-js",
-  "version": "0.1.26",
+  "version": "0.1.28",
   "license": "Apache-2.0",
   "description": "JSONata embedded in JSON",
   "main": "./dist/src/TemplateProcessor.js",

--- a/src/ExecutionStatus.ts
+++ b/src/ExecutionStatus.ts
@@ -1,7 +1,6 @@
 import {MetaInfo} from "./MetaInfoProducer.js";
 import TemplateProcessor, {Fork, MetaInfoMap, Plan, PlanStep} from "./TemplateProcessor.js";
 import {NOOP_PLACEHOLDER, stringifyTemplateJSON, UNDEFINED_PLACEHOLDER} from './utils/stringify.js';
-import StatedREPL from "./StatedREPL.js";
 
 export class ExecutionStatus {
     public statuses: Set<Plan>;

--- a/src/StatedREPL.ts
+++ b/src/StatedREPL.ts
@@ -15,7 +15,7 @@ import repl from 'repl';
 import CliCore from './CliCore.js';
 import colorizeJson from "json-colorizer";
 import chalk from 'chalk';
-import { circularReplacer, stringifyTemplateJSON } from './utils/stringify.js';
+import { stringifyTemplateJSON as stringify } from './utils/stringify.js';
 import TemplateProcessor from "./TemplateProcessor.js";
 
 
@@ -63,7 +63,7 @@ export default class StatedREPL {
         const {oneshot} = CliCore.parseInitArgs(cmdLineArgsStr)
         const resp = await this.cliCore.init(cmdLineArgsStr)
         if(oneshot){
-            console.log(StatedREPL.stringify(resp));
+            console.log(stringify(resp));
             return; //do not start REPL. We produced oneshot output, now bail
         }
         //crank up the interactive REPL
@@ -128,26 +128,16 @@ export default class StatedREPL {
             const method = (this.cliCore as any)[cliCoreMethodName].bind(this.cliCore);
             result = await method(args);
             if(!this.tookOverIO(cliCoreMethodName, result)){
-                let stringify = StatedREPL.stringify(result);
-                if(this.isColorized === true){
-                    stringify = StatedREPL.colorize(stringify);
+                let s = stringify(result);
+                if(this.isColorized){
+                    s = StatedREPL.colorize(s);
                 }
-                console.log(stringify);
+                console.log(s);
             }
         } catch (e:any) {
-            const stringify = StatedREPL.stringify(e.message);
-            console.error(stringify);
-            result = "";
+            console.error(stringify(e.message));
         }
         this.r.displayPrompt();
-    }
-
-    static printFunc(key:string, value:any) {
-        return circularReplacer(key, value);
-    }
-
-    static stringify(o: any, printFunction?: (k: any, v: any) => any) {
-        return stringifyTemplateJSON(o, printFunction)
     }
 
     static colorize(s:string):string{

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -23,7 +23,7 @@ import fs from 'fs';
 import ConsoleLogger, {Levels, LOG_LEVELS, StatedLogger} from "./ConsoleLogger.js";
 import FancyLogger from "./FancyLogger.js";
 import {TimerManager} from "./TimerManager.js";
-import {stringifyTemplateJSON} from './utils/stringify.js';
+import {stringifyTemplateJSON as stringify} from './utils/stringify.js';
 import {debounce} from "./utils/debounce.js"
 import {rateLimit} from "./utils/rateLimit.js"
 import {ExecutionStatus} from "./ExecutionStatus.js";
@@ -31,7 +31,7 @@ import {Sleep} from "./utils/Sleep.js";
 import {saferFetch} from "./utils/FetchWrapper.js";
 import {env} from "./utils/env.js"
 import * as jsonata from "jsonata";
-import StatedREPL from "./StatedREPL.js";
+
 
 declare const BUILD_TARGET: string | undefined;
 
@@ -1111,8 +1111,8 @@ export default class TemplateProcessor {
         const plan:Plan = {sortedJsonPtrs: fromPlan, restoreJsonPtrs: [], data, op, output:this.output, forkStack:[], forkId:"ROOT", didUpdate:[]}
         this.executionQueue.push(plan);
         if(this.isEnabled("debug")) {
-            this.logger.debug(`execution plan (uid=${this.uniqueId}): ${StatedREPL.stringify(plan)}`);
-            this.logger.debug(`execution plan queue (uid=${this.uniqueId}): ${StatedREPL.stringify(this.executionQueue)}`);
+            this.logger.debug(`execution plan (uid=${this.uniqueId}): ${stringify(plan)}`);
+            this.logger.debug(`execution plan queue (uid=${this.uniqueId}): ${stringify(this.executionQueue)}`);
         }
         if(this.executionQueue.length>1){
             return fromPlan; //if there is a plan in front of ours in the executionQueue it will be handled by the already-awaited drainQueue
@@ -1167,7 +1167,7 @@ export default class TemplateProcessor {
     private logOutput(output:any) {
         if (this.isEnabled("debug")) {
             this.logger.debug(`----------------TEMPLATE OUTPUT (${this.uniqueId})-----------------`)
-            this.logger.debug(stringifyTemplateJSON(output));
+            this.logger.debug(stringify(output));
         }
     }
 
@@ -1507,9 +1507,9 @@ export default class TemplateProcessor {
             this.logger.error(`Error evaluating expression at ${jsonPtr}`);
             this.logger.error(error);
             this.logger.debug(`Expression: ${expr__}`);
-            this.logger.debug(`Target: ${stringifyTemplateJSON(target)}`);
-            this.logger.debug(`Target: ${stringifyTemplateJSON(target)}`);
-            this.logger.debug(`Result: ${stringifyTemplateJSON(evaluated)}`);
+            this.logger.debug(`Target: ${stringify(target)}`);
+            this.logger.debug(`Target: ${stringify(target)}`);
+            this.logger.debug(`Result: ${stringify(evaluated)}`);
             const _error = new Error(error.message);
             _error.name = "JSONata evaluation exception";
             throw _error;

--- a/src/test/MetaInfoProducer.test.js
+++ b/src/test/MetaInfoProducer.test.js
@@ -1,5 +1,5 @@
 import MetaInfoProducer from '../../dist/src/MetaInfoProducer.js';
-import StatedREPL from '../../dist/src/StatedREPL.js';
+import {stringifyTemplateJSON as stringify} from '../../dist/src/utils/stringify.js';
 
 
 test("tt1", async () => {
@@ -9,7 +9,7 @@ test("tt1", async () => {
         "c": "${'the answer is: '& b}"
     };
     const metaInfos = await MetaInfoProducer.getMetaInfos(template);
-    expect(JSON.parse(JSON.stringify(metaInfos, StatedREPL.printFunc, 2))).toEqual([
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
         {
             "absoluteDependencies__": [],
             "dependees__": [],
@@ -81,7 +81,7 @@ test("t2", async () => {
         }
     };
     const metaInfos = await MetaInfoProducer.getMetaInfos(template);
-    expect(JSON.parse(JSON.stringify(metaInfos, StatedREPL.printFunc, 2))).toEqual([
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
         {
             "absoluteDependencies__": [],
             "dependees__": [],
@@ -237,7 +237,7 @@ test("t3", async () => {
         "l": "${j}"
     };
     const metaInfos = await MetaInfoProducer.getMetaInfos(template);
-    expect(JSON.parse(JSON.stringify(metaInfos, StatedREPL.printFunc, 2))).toEqual([
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
         {
             "absoluteDependencies__": [],
             "dependees__": [],
@@ -647,7 +647,7 @@ test("temp vars 1", async () => {
         "a":"!${42}",
     };
     const metaInfos = await MetaInfoProducer.getMetaInfos(template);
-    expect(JSON.parse(JSON.stringify(metaInfos, StatedREPL.printFunc, 2))).toEqual([
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
         {
             "absoluteDependencies__": [],
             "dependees__": [],
@@ -698,7 +698,7 @@ test("temp vars 2", async () => {
         "c": "${b4}" //non-existant node reference
     };
     const metaInfos = await MetaInfoProducer.getMetaInfos(template);
-    expect(JSON.parse(JSON.stringify(metaInfos, StatedREPL.printFunc, 2))).toEqual([
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
         {
             "absoluteDependencies__": [],
             "dependees__": [],
@@ -973,7 +973,7 @@ test("temp vars 3", async () => {
         }
     };
     const metaInfos = await MetaInfoProducer.getMetaInfos(template);
-    expect(JSON.parse(JSON.stringify(metaInfos, StatedREPL.printFunc, 2))).toEqual([
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
         {
             "absoluteDependencies__": [],
             "dependees__": [],

--- a/src/test/StatedREPL.test.js
+++ b/src/test/StatedREPL.test.js
@@ -14,9 +14,10 @@
 
 import StatedREPL from "../../dist/src/StatedREPL.js";
 import TemplateProcessor from "../../dist/src/TemplateProcessor.js";
+import {stringifyTemplateJSON as stringify} from "../../dist/src/utils/stringify.js"
 
 test("test stringify", async () => {
-  expect(StatedREPL.stringify({a: 1, b: 2})).toBe(
+  expect(stringify({a: 1, b: 2})).toBe(
     `{
   "a": 1,
   "b": 2
@@ -25,7 +26,7 @@ test("test stringify", async () => {
 
 test("test stringify custom print function", async () => {
   const customPrintFunc = (k,v) => {return k === "a" ? null : v}
-  expect(StatedREPL.stringify({ a: 1, b: 2 }, customPrintFunc)).toBe(
+  expect(stringify({ a: 1, b: 2 }, customPrintFunc)).toBe(
     `{
   "a": null,
   "b": 2
@@ -93,7 +94,7 @@ test("Extend CliCore with restore command", async () => {
     // we call restore on the repl, which will expect it to be defined in CliCore.
     await repl.cli('restore', '-f example/restoreSnapshot.json');
 
-    console.log(StatedREPL.stringify(repl.cliCore.templateProcessor.output));
+    console.log(stringify(repl.cliCore.templateProcessor.output));
     expect(repl.cliCore.templateProcessor.output).toBeDefined();
     expect(repl.cliCore.templateProcessor.output.count).toBeGreaterThanOrEqual(3); // should be 3 or more right after restoring from the snapshot
     expect(repl.cliCore.templateProcessor.output.count).toBeLessThan(10); // ... but less than 10


### PR DESCRIPTION
fix web targets by making sure no references to node stuff creeps into TemplateProcessor

## Description
make sure everyone uses utils/stringify and remove stringify method from TemplateProcessor so folks don't create accidental transitive references to Node stuff by importing the stringify method.

## Type of Change

- [x ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ x] Existing issues have been referenced (where applicable)
- [ x] I have verified this change is not present in other open pull requests
- [ x] Functionality is documented
- [x ] All code style checks pass
- [ x] New code contribution is covered by automated tests
- [ x] All new and existing tests pass
