### PR TITLE
fix main entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.32",
   "license": "Apache-2.0",
   "description": "JSONata embedded in JSON",
-  "main": "./dist/src/TemplateProcessor.js",
-  "module": "./dist/src/TemplateProcessor.js",
+  "main": "./dist/src/index.js",
+  "module": "./dist/src/index.js",
   "exports": {
     ".": {
       "import": "./dist/bundle.mjs",
@@ -17,6 +17,7 @@
     "./dist/src/TestUtils.js": "./dist/src/TestUtils.js",
     "./dist/src/DependencyFinder.js": "./dist/src/DependencyFinder.js",
     "./dist/src/JsonPointer.js": "./dist/src/JsonPointer.js",
+    "./dist/src/utils/stringify.js": "./dist/src/utils/stringify.js",
     "./dist/src/utils/debounce.js": "./dist/src/utils/debounce.js",
     "./dist/src/utils/rateLimit.js": "./dist/src/utils/rateLimit.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,8 @@
+// src/index.ts
+
+export { default } from './TemplateProcessor.js';
+export * from './TemplateProcessor.js';
+export * as MetaInfoProducer from './MetaInfoProducer.js';
+export {default as JsonPointer} from './JsonPointer.js'
+export {stringifyTemplateJSON} from './utils/stringify.js'
+

--- a/webpack.config.cjs.js
+++ b/webpack.config.cjs.js
@@ -12,7 +12,7 @@ export default {
 
     devtool: 'source-map',
     entry: {
-        main: './dist/src/TemplateProcessor.js'
+        main: './dist/src/index.js'
     },
     output: {
         path: `${__dirname}/dist`, // Use __dirname here

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ export default {
     devtool: 'source-map', //generate sourcemaps so other projects can debug into stated
     mode: 'production',
     entry: {
-        main: './dist/src/TemplateProcessor.js'
+        main: './dist/src/index.js'
     },
     output: {
         path: `${__dirname}/dist`, // Use __dirname here


### PR DESCRIPTION

## Description

package.json and webpack configs should point to index as the main, since that is where all the exports are that define the module

## Type of Change

- [ x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
