### PR TITLE
improve execute to eliminate race conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stated-js",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "license": "Apache-2.0",
   "description": "JSONata embedded in JSON",
   "main": "./dist/src/index.js",

--- a/src/ParallelExecutionPlanDefault.ts
+++ b/src/ParallelExecutionPlanDefault.ts
@@ -16,6 +16,8 @@ export class ParallelExecutionPlanDefault implements ParallelExecutionPlan {
     jsonPtr: JsonPointerString = "/";
     didUpdate: boolean = false;
     restore?: boolean = false;
+    circular?:boolean;
+
     constructor(tp: TemplateProcessor, parallelSteps: ParallelExecutionPlan[] = [], vals?: Partial<ParallelExecutionPlan> | null) {
         this.output = tp.output;
         this.parallel = parallelSteps;
@@ -38,6 +40,9 @@ export class ParallelExecutionPlanDefault implements ParallelExecutionPlan {
         if (p.data) {
             (json as any).data = p.data;
         }
+        if(p.circular){
+            (json as any).circular = p.circular
+        }
         return json;
     }
 
@@ -46,7 +51,7 @@ export class ParallelExecutionPlanDefault implements ParallelExecutionPlan {
     }
 
     cleanCopy(tp: TemplateProcessor, source: ParallelExecutionPlanDefault = this): ParallelExecutionPlanDefault {
-        return new ParallelExecutionPlanDefault(tp, [], {
+        const fields:any = {
             op: source.op,
             parallel: source.parallel.map(p => source.cleanCopy(tp, p as any)),
             completed: false,
@@ -55,7 +60,11 @@ export class ParallelExecutionPlanDefault implements ParallelExecutionPlan {
             forkId: "ROOT",
             didUpdate: false,
             data: source.data
-        });
+        };
+        if(source.circular){
+            fields.circular = source.circular;
+        }
+        return new ParallelExecutionPlanDefault(tp, [], fields);
     }
 
     getNodeList(all: boolean = false): JsonPointerString[] {

--- a/src/TemplateProcessor.ts
+++ b/src/TemplateProcessor.ts
@@ -76,7 +76,8 @@ export type PlanStep = {
     output:object,
     forkStack:Fork[],
     forkId:string,
-    didUpdate:boolean
+    didUpdate:boolean,
+    circular?:boolean
 }
 export type Mutation =  {jsonPtr:JsonPointerString, op:Op, data:any};
 

--- a/src/TraversalState.ts
+++ b/src/TraversalState.ts
@@ -21,6 +21,7 @@ export class TraversalState {
             const e = '🔃 Circular dependency  ' + this.stack.map(n => n.jsonPtr).join(' → ') + " → " + jsonPtr;
             this.tp.warnings.push(e);
             this.tp.logger.log('warn', e);
+            node.circular = true; //flag this step as circular so that during plan execution we can drop circular steps
             return false;
         }
         if (this.stack[this.stack.length - 1]?.op === "noop") {

--- a/src/test/TemplateProcessor.test.js
+++ b/src/test/TemplateProcessor.test.js
@@ -5491,6 +5491,7 @@ test("total cost example", async () => {
                                     "op": "initialize",
                                     "parallel": [
                                         {
+                                            "circular": true,
                                             "completed": false,
                                             "didUpdate": false,
                                             "forkId": "ROOT",
@@ -5510,6 +5511,7 @@ test("total cost example", async () => {
                                     "op": "initialize",
                                     "parallel": [
                                         {
+                                            "circular": true,
                                             "completed": false,
                                             "didUpdate": false,
                                             "forkId": "ROOT",
@@ -5529,6 +5531,7 @@ test("total cost example", async () => {
                                     "op": "initialize",
                                     "parallel": [
                                         {
+                                            "circular": true,
                                             "completed": false,
                                             "didUpdate": false,
                                             "forkId": "ROOT",


### PR DESCRIPTION
## Description

it was possible that there could be race conditions in parallel plans, because the _execute promise started before it was put in the promises map. This code fixes it, and deals with deadlocks that happen in circular plans by adding circular:boolean to the PlanStep so that execution can be stopped when circularity is detected.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [x ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
