### PR TITLE
Add 'no_entry' emoji to avoid expression evaluation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Deploy TypeDocs
         uses: peaceiris/actions-gh-pages@v3.9.3 
         with:
-          personal_token: ${{ secrets.GH_PAT }}
+          github_token: ${{ secrets.GH_PAT }}
           publish_dir: ./docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Deploy TypeDocs
         uses: peaceiris/actions-gh-pages@v3.9.3 
         with:
-          github_token: ${{ secrets.GH_PAT }}
+          personal_token: ${{ secrets.GH_PAT }}
           publish_dir: ./docs

--- a/README.md
+++ b/README.md
@@ -872,6 +872,76 @@ expression are also tagged.
 }
 
 ```
+## Blocked Properties with ⛔
+Properties whose names start with "⛔" are completely ignored during template processing. This is useful for:
+
+1. Adding notes or comments that should not be evaluated
+2. Temporarily disabling parts of a template
+3. Keeping sensitive or debug information in the template but preventing its evaluation
+
+When a property name starts with "⛔", the MetaInfoProducer will skip that property and all of its children, effectively making them invisible to the template processor.
+
+```json
+> .init -f "example/ex25.json"
+{
+  "a": 42,
+  "⛔b": "${$string('should not be evaluated: ') & a}",
+  "c": "${a}"
+}
+> .out
+{
+  "a": 42,
+  "⛔b": "${$string('should not be evaluated: ') & a}",
+  "c": 42
+}
+> .init -f "example/ex26.json"
+{
+  "a": 42,
+  "⛔note": "${$string('Will NOT be evaluated: ') & a}",
+  "note": "${$string('Will be evaluated: ') & a}",
+  "config": {
+    "⛔productionDb": "${$env('DB_PROD_URL', 'mysql://prod.example.com:3306')}",
+    "productionDb": "${$env('DB_PROD_URL', 'mysql://prod.example.com:3306')}",
+    "localDb": "mysql://localhost:3306"
+  },
+  "features": {
+    "⛔experimental": {
+      "enabled": true,
+      "endpoint": "${$string('https://api.example.com/config/') & 'experimental'}"
+    },
+    "experimental": {
+      "enabled": true,
+      "endpoint": "${$string('https://api.example.com/config/') & 'experimental'}"
+    }
+  }
+}
+> .out
+{
+  "a": 42,
+  "⛔note": "${$string('Will NOT be evaluated: ') & a}",
+  "note": "Will be evaluated: 42",
+  "config": {
+    "⛔productionDb": "${$env('DB_PROD_URL', 'mysql://prod.example.com:3306')}",
+    "productionDb": "mysql://prod.example.com:3306",
+    "localDb": "mysql://localhost:3306"
+  },
+  "features": {
+    "⛔experimental": {
+      "enabled": true,
+      "endpoint": "${$string('https://api.example.com/config/') & 'experimental'}"
+    },
+    "experimental": {
+      "enabled": true,
+      "endpoint": "https://api.example.com/config/experimental"
+    }
+  }
+}
+```
+
+In these examples, `⛔...` will be completely ignored during template processing - the expression will not be evaluated.
+
+Note that array elements with "⛔" in their values will still be processed, as array indices are numbers, not property names. Only object properties that start with "⛔" are blocked.
+
 # Generative Templates
 Templates can contain generative expressions that cause their content to change over time. 
 For instance the `$setInterval` function behaves exactly as it does in Javascript. Below, 

--- a/README.md
+++ b/README.md
@@ -885,13 +885,13 @@ When a property name starts with "⛔", the MetaInfoProducer will skip that prop
 > .init -f "example/ex25.json"
 {
   "a": 42,
-  "⛔b": "${$string('should not be evaluated: ') & a}",
+  "⛔note": "${$string('should not be evaluated: ') & a}",
   "c": "${a}"
 }
 > .out
 {
   "a": 42,
-  "⛔b": "${$string('should not be evaluated: ') & a}",
+  "⛔note": "${$string('should not be evaluated: ') & a}",
   "c": 42
 }
 > .init -f "example/ex26.json"

--- a/example/ex25.json
+++ b/example/ex25.json
@@ -1,0 +1,5 @@
+{
+    "a": 42,
+    "⛔note": "${$string('should not be evaluated: ') & a}",
+    "c": "${a}"
+}

--- a/example/ex26.json
+++ b/example/ex26.json
@@ -1,0 +1,20 @@
+{
+    "a": 42,
+    "⛔note": "${$string('Will NOT be evaluated: ') & a}",
+    "note": "${$string('Will be evaluated: ') & a}",
+    "config": {
+        "⛔productionDb": "${$env('DB_PROD_URL', 'mysql://prod.example.com:3306')}",
+        "productionDb": "${$env('DB_PROD_URL', 'mysql://prod.example.com:3306')}",
+        "localDb": "mysql://localhost:3306"
+    },
+    "features": {
+        "⛔experimental": {
+            "enabled": true,
+            "endpoint": "${$string('https://api.example.com/config/') & 'experimental'}"
+        },
+        "experimental": {
+            "enabled": true,
+            "endpoint": "${$string('https://api.example.com/config/') & 'experimental'}"
+        }
+    }
+}

--- a/src/MetaInfoProducer.ts
+++ b/src/MetaInfoProducer.ts
@@ -57,6 +57,8 @@ export default class MetaInfoProducer {
         const emit: MetaInfo[] = [];
 
         async function getPaths(o:any, path: JsonPointerStructureArray = [], isTemp=false) {
+            if (String(path.at(-1))[0] === '⛔') return;
+            
             const type = typeof o;
             const metaInfo: MetaInfo = {
                 "materialized__": true,

--- a/src/test/MetaInfoProducer.test.js
+++ b/src/test/MetaInfoProducer.test.js
@@ -1117,5 +1117,261 @@ test("temp vars 3", async () => {
     ]);
 });
 
+test("blocked paths with ⛔ character 1", async () => {
+    const template = {
+        "a": 42,
+        "⛔b": "Should be ignored",
+        "c": "${a}"
+    };
+    const metaInfos = await MetaInfoProducer.getMetaInfos(template);
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "a"
+            ],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "exprRootPath__": null,
+            "exprTargetJsonPointer__": [],
+            "expr__": "a",
+            "jsonPointer__": [
+                "c"
+            ],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": true
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": true
+        }
+    ]);
+});
+
+test("blocked paths with ⛔ character 2", async () => {
+    const template = {
+        "a": 42,
+        "b": {
+            "normal": "value",
+            "⛔secret": {
+                "nested": "This should be ignored"
+            }
+        },
+        "c": "${a}"
+    };
+    const metaInfos = await MetaInfoProducer.getMetaInfos(template);
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "a"
+            ],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "b",
+                "normal"
+            ],
+            "materialized__": true,
+            "parent__": [
+                "b"
+            ],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "b"
+            ],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "exprRootPath__": null,
+            "exprTargetJsonPointer__": [],
+            "expr__": "a",
+            "jsonPointer__": [
+                "c"
+            ],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": true
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": true
+        }
+    ]);
+});
+
+test("blocked paths with ⛔ character in array", async () => {
+    const template = {
+        "a": 42,
+        "arr": [
+            "normal",
+            "⛔blocked", // This should be included since array indices are numbers, not strings with ⛔
+            {
+                "⛔key": "blocked object key",
+                "normal": "normal object key"
+            }
+        ]
+    };
+    const metaInfos = await MetaInfoProducer.getMetaInfos(template);
+    expect(JSON.parse(stringify(metaInfos))).toEqual([
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "a"
+            ],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "arr",
+                0
+            ],
+            "materialized__": true,
+            "parent__": [
+                "arr"
+            ],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "arr",
+                1
+            ],
+            "materialized__": true,
+            "parent__": [
+                "arr"
+            ],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "arr",
+                2,
+                "normal"
+            ],
+            "materialized__": true,
+            "parent__": [
+                "arr",
+                2
+            ],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "arr",
+                2
+            ],
+            "materialized__": true,
+            "parent__": [
+                "arr"
+            ],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [
+                "arr"
+            ],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        },
+        {
+            "absoluteDependencies__": [],
+            "dependees__": [],
+            "dependencies__": [],
+            "jsonPointer__": [],
+            "materialized__": true,
+            "parent__": [],
+            "tags__": [],
+            "temp__": false,
+            "treeHasExpressions__": false
+        }
+    ]);
+});
+
 
 


### PR DESCRIPTION
Minor update to avoid expression evaluation when the path key starts with "⛔".